### PR TITLE
Upgrade cassandra dependency to v4.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <version.cassandra.all>4.1.2</version.cassandra.all>
+        <version.cassandra.all>4.1.4</version.cassandra.all>
 
         <version.maven.release.plugin>2.5.3</version.maven.release.plugin>
         <version.maven.dependency.plugin>3.1.1</version.maven.dependency.plugin>


### PR DESCRIPTION
This fixes the following exception when scraping metrics in Cassandra v4.1.4:
`java.lang.NoSuchMethodError: 'com.google.common.collect.ImmutableSet org.apache.cassandra.schema.Schema.getKeyspaces()'`